### PR TITLE
Fix 'command not found' error

### DIFF
--- a/labs/exploring/start.sh
+++ b/labs/exploring/start.sh
@@ -3,17 +3,17 @@
 docker-compose up -d
 
 echo "Waiting for Kafka to launch on 9092..."
-while ! nc -z kafka 9092; do   
+while ! nc -z kafka 9092; do
   sleep 1.0
   echo "Kafka not yet ready..."
-done 
+done
 echo "Kafka is now ready!"
 
-kafka-topics --bootstrap-server kafka:9092 \
-    --topic vehicle-positions \
-    --create \
-    --partitions 6 \
-    --replication-factor 1
+docker exec exploring-kafka-1 kafka-topics --bootstrap-server kafka:9092 \
+  --topic vehicle-positions \
+  --create \
+  --partitions 6 \
+  --replication-factor 1
 
 docker container run -d \
     --name producer \


### PR DESCRIPTION
- add docker exec to beginning of command to make sure it runs in the proper container