### PR TITLE
changes needed for this to work

### DIFF
--- a/labs/advanced-topics/consumer/build.gradle
+++ b/labs/advanced-topics/consumer/build.gradle
@@ -11,7 +11,7 @@ repositories {
 }
 
 jar {
-    baseName = 'vp-consumer'
+    archiveBaseName = 'vp-consumer'
 }
 
 sourceCompatibility = 1.8

--- a/labs/confluent-platform/docker-compose.yml
+++ b/labs/confluent-platform/docker-compose.yml
@@ -57,6 +57,7 @@ services:
     ports:
       - 9021:9021
     environment:
+      CONTROL_CENTER_KSQL_KSQLDB_ADVERTISED_URL: "http://localhost:8088"
       CONTROL_CENTER_BOOTSTRAP_SERVERS: kafka:9092
       CONTROL_CENTER_ZOOKEEPER_CONNECT: zookeeper:2181
       CONTROL_CENTER_REPLICATION_FACTOR: 1


### PR DESCRIPTION
ran into problems when using the 7.1.1-v1.0.0 tag to complete the Apache Kafka Fundamentals course, here are the fixes
(btw, the version in docker-compose.yml file is also deprecated now)