### PR TITLE
Fix: use vp-producer-fallback image and add --if-not-exists to topic creation

### DIFF
--- a/labs/exploring/docker-compose.yml
+++ b/labs/exploring/docker-compose.yml
@@ -29,6 +29,10 @@ services:
       # Replace CLUSTER_ID with a unique base64 UUID using "bin/kafka-storage.sh random-uuid"
       # See https://docs.confluent.io/kafka/operations-tools/kafka-tools.html#kafka-storage-sh
       CLUSTER_ID: 'Nk018hRAQFytWskYqtQduw'
+      KAFKA_CONFLUENT_LICENSE_TOPIC_REPLICATION_FACTOR: 1
+      KAFKA_CONFLUENT_BALANCER_TOPIC_REPLICATION_FACTOR: 1
+      CONFLUENT_METRICS_REPORTER_TOPIC_REPLICAS: 1
+      KAFKA_CONFLUENT_LICENSE: ""
 
 networks:
   confluent:

--- a/labs/exploring/start.sh
+++ b/labs/exploring/start.sh
@@ -39,7 +39,7 @@ kafka-topics --bootstrap-server kafka:9092 \
     --create \
     --if-not-exists \
     --partitions 6 \
-    --replication-factor 1 
+    --replication-factor 1
 
 cat << EOF
 Topic created.

--- a/labs/exploring/start.sh
+++ b/labs/exploring/start.sh
@@ -37,8 +37,9 @@ EOF
 kafka-topics --bootstrap-server kafka:9092 \
     --topic vehicle-positions \
     --create \
+    --if-not-exists \
     --partitions 6 \
-    --replication-factor 1
+    --replication-factor 1 
 
 cat << EOF
 Topic created.
@@ -49,7 +50,7 @@ EOF
 docker container run -d \
     --name producer \
     --net exploring_confluent \
-    cnfltraining/vp-producer:v2
+    cnfltraining/vp-producer-fallback:v2
 
 echo "Producer up and running!"
 


### PR DESCRIPTION
## Problem
Two issues affecting lab usability:

1. `cnfltraining/vp-producer:v2` fails with an SSL handshake error (PKIX path building failed) when connecting to the MQTT broker, making the lab completely unusable.

2. Re-running `start.sh` fails if the `vehicle-positions` topic already  exists, requiring manual cleanup between runs.

## Changes
- Switch producer image from `cnfltraining/vp-producer:v2` to  `cnfltraining/vp-producer-fallback:v2` which resolves the SSL issue
- Add `--if-not-exists` flag to `kafka-topics --create` so start.sh is idempotent and can be safely re-run

## Testing
Verified on Apple Silicon (M2 Pro) via UTM VM running Linux/ARM64 with Docker and QEMU x86 emulation.